### PR TITLE
Change where we enter settings for config.php

### DIFF
--- a/filemanager/plugin.js
+++ b/filemanager/plugin.js
@@ -16,19 +16,38 @@ tinymce.PluginManager.add('filemanager', function(editor) {
 		urltype=2;
 		if (type=='image') { urltype=1; }
 		if (type=='media') { urltype=3; }
-                var title="RESPONSIVE FileManager";
-                if (typeof tinymce.settings.filemanager_title !== "undefined" && tinymce.settings.filemanager_title) 
-                    title=tinymce.settings.filemanager_title;
-                var sort_by="";
-                var descending="false";
+		var title="RESPONSIVE FileManager";
+		if (typeof tinymce.settings.filemanager_title !== "undefined" && tinymce.settings.filemanager_title) 
+			title=tinymce.settings.filemanager_title;
+		var sort_by="";
+		var descending="false";
 		if (typeof tinymce.settings.filemanager_sort_by !== "undefined" && tinymce.settings.filemanager_sort_by) 
-                    sort_by=tinymce.settings.filemanager_sort_by;
+					sort_by=tinymce.settings.filemanager_sort_by;
 		if (typeof tinymce.settings.filemanager_descending !== "undefined" && tinymce.settings.filemanager_descending) 
-                    descending=tinymce.settings.filemanager_descending;
+					descending=tinymce.settings.filemanager_descending;
+
+		// SETTINGS TO REMOVE DEPENDANCY OF CONFIG.PHP
+		var base_url = 'http://rfm';
+		if (typeof tinymce.settings.rfmConfig_base_url !== "undefined" && tinymce.settings.rfmConfig_base_url) {
+			base_url=tinymce.settings.rfmConfig_base_url;
+		}
+		var upload_dir = '/source/';
+		if (typeof tinymce.settings.rfmConfig_upload_dir !== "undefined" && tinymce.settings.rfmConfig_upload_dir) {
+			upload_dir=tinymce.settings.rfmConfig_upload_dir;
+		}
+		var current_path = '../source/';
+		if (typeof tinymce.settings.rfmConfig_current_path !== "undefined" && tinymce.settings.rfmConfig_current_path) {
+			current_path=tinymce.settings.rfmConfig_current_path;
+		}
+		var thumbs_base_path = '../thumbs/';
+		if (typeof tinymce.settings.rfmConfig_thumbs_base_path !== "undefined" && tinymce.settings.rfmConfig_thumbs_base_path) {
+			thumbs_base_path=tinymce.settings.rfmConfig_thumbs_base_path;
+		}
+					
 		tinymce.activeEditor.windowManager.open({
 			title: title,
-			file: tinymce.settings.external_filemanager_path+'dialog.php?type='+urltype+'&descending='+descending+'&sort_by='+sort_by+'&lang='+tinymce.settings.language,
-			width: 870,  
+			file: tinymce.settings.external_filemanager_path+'dialog.php?type='+urltype+'&descending='+descending+'&sort_by='+sort_by+'&lang='+tinymce.settings.language+'&base_url='+base_url+'&upload_dir='+upload_dir+'&current_path='+current_path+'&thumbs_base_path='+thumbs_base_path,
+			width: 870,	
 			height: 570,
 			resizable: true,
 			maximizable: true,


### PR DESCRIPTION
To make upgrading easier, move where we enter settings so that they are not lost when we overwrite config.php. This will require saving these vars in session. So config.php will have to be updated as well as the tinymce init() accordingly.
