### PR TITLE
Update upload.php

### DIFF
--- a/filemanager/upload.php
+++ b/filemanager/upload.php
@@ -11,9 +11,10 @@ $path_pos=strpos($storeFolder,$current_path);
 $thumb_pos=strpos($_POST['path_thumb'],$thumbs_base_path);
 if($path_pos!==0 
     || $thumb_pos !==0
-    || strpos($_POST['path_thumb'],'../',strlen($thumbs_base_path)+$thumb_pos)!==FALSE
-    || strpos($storeFolder,'../',strlen($current_path)+$path_pos)!==FALSE
-    || strpos($storeFolder,'./',strlen($current_path)+$path_pos)!==FALSE )
+    || strpos($storeFolderThumb,'../',strlen($thumbs_base_path))!==FALSE
+    || strpos($storeFolderThumb,'./',strlen($thumbs_base_path))!==FALSE
+    || strpos($storeFolder,'../',strlen($current_path))!==FALSE
+    || strpos($storeFolder,'./',strlen($current_path))!==FALSE )
     die('wrong path');
 
 


### PR DESCRIPTION
It seems logical to add this line, since such verification exists for $storeFolder:

``` php
strpos($storeFolderThumb,'./',strlen($thumbs_base_path))!==FALSE
```

Also replaced `php $_POST['path_thumb']` with descriptive name, and removed that `php +$thumb_pos` and `php +$path_pos` because at this lines we are already sure both values equal to 0.

Besides that, I'm not sure if this code does anything useful:

``` php
    else{
        move_uploaded_file($tempFile,$targetFile);
        chmod($targetFile, 0755);
    }
```

because we are already moved uploaded file at the beginning (lines 60-61)
