### PR TITLE
Update dialog.php

### DIFF
--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -695,6 +695,7 @@ $files=array_merge(array($prev_folder),array($current_folder),$sorted);
 		<li class="ff-item-type-<?php echo $class_ext; ?> file"  data-name="<?php echo $file; ?>"><?php 
                     $file_prevent_rename = false;
                     $file_prevent_delete = false;
+                    $files_prevent_duplicate = array();
                     if (isset($filePermissions[$file])) {
                         if (isset($filePermissions[$file]['prevent_duplicate']) && $filePermissions[$file]['prevent_duplicate']) {
                             $files_prevent_duplicate[] = $file; 


### PR DESCRIPTION
Sorry, new to GitHub fork, pull requests etc.

Downloaded 9.3.3 off your website. Installed it and found an issue when right clicking it would throw an error in the console:

Uncaught ReferenceError: files_prevent_duplicate is not defined include.min.js:1

I did some digging and found that there was no array being declared in:
**/filemanager/dialog.php**.

Since declaring the array, the issue went away and I was able to right click again.
