### PR TITLE
Add support for TinyMCE 3.X (updated include.js)

### DIFF
--- a/filemanager/js/include.js
+++ b/filemanager/js/include.js
@@ -710,8 +710,19 @@ function apply(file,external){
 	}
 	
     }
-    parent.tinymce.activeEditor.insertContent(fill);
-    parent.tinymce.activeEditor.windowManager.close();
+	
+	// tinymce 3.X
+    if ( parent.tinymce.majorVersion < 4 )
+    {
+		parent.tinymce.activeEditor.execCommand('mceInsertContent', false, fill); 
+		parent.tinymce.activeEditor.windowManager.close( parent.tinymce.activeEditor.windowManager.params.mce_window_id );
+	}
+	// tinymce 4.X
+	else 
+	{
+		parent.tinymce.activeEditor.insertContent(fill);
+		parent.tinymce.activeEditor.windowManager.close();
+	}
 }
 
 
@@ -795,8 +806,18 @@ function apply_none(file,external){
 
 function apply_any(path, file) {
 	path = path.replace('\\', '/');
-	parent.tinymce.activeEditor.windowManager.getParams().setUrl(path+file);
-	parent.tinymce.activeEditor.windowManager.close();
+	// tinymce 3.X
+	if ( parent.tinymce.majorVersion < 4 )
+	{
+		parent.tinymce.activeEditor.windowManager.params.setUrl(path+file);
+		parent.tinymce.activeEditor.windowManager.close( parent.tinymce.activeEditor.windowManager.params.mce_window_id );
+	}
+	// tinymce 4.X
+	else
+	{
+		parent.tinymce.activeEditor.windowManager.getParams().setUrl(path+file);
+		parent.tinymce.activeEditor.windowManager.close();
+	}
 	return false;	
 }
 


### PR DESCRIPTION
- add support for tinymce 3.X

We use responsivefilemanager in a Drupal 7 project. Since Drupal support for TinyMCE 4.X is still in development, I added support for TinyMCE 3.X.
