### PR TITLE
Fixed bug with folder size calculation

### DIFF
--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -501,7 +501,11 @@ foreach($files as $k=>$file){
     elseif($file=="..") $prev_folder=array('file'=>$file);
     elseif(is_dir($current_path.$rfm_subfolder.$subdir.$file)){
 	$date=filemtime($current_path.$rfm_subfolder.$subdir. $file);
-	$size=foldersize($current_path.$rfm_subfolder.$subdir. $file);
+	if($show_folder_size){
+		$size=foldersize($current_path.$rfm_subfolder.$subdir. $file);
+	} else {
+		$size=0;
+	}
 	$file_ext=lang_Type_dir;
 	$sorted[$k]=array('file'=>$file,'date'=>$date,'size'=>$size,'extension'=>$file_ext);
     }else{


### PR DESCRIPTION
Folder size should not be calculated when $show_folder_size is FALSE. This fix greatly increases browsing speed.
