### PR TITLE
Added support for additional Aviary config options

### DIFF
--- a/filemanager/config/config.php
+++ b/filemanager/config/config.php
@@ -180,10 +180,14 @@ $ext = array_merge($ext_img, $ext_file, $ext_misc, $ext_video,$ext_music); //all
  * AVIARY config
 *******************/
 $aviary_active 	= TRUE;
-$aviary_key 	= "dvh8qudbp6yx2bnp";
 $aviary_secret	= "m6xaym5q42rpw433";
-$aviary_version	= 3;
-$aviary_language= 'en';
+// Add or modify the Aviary options below as needed - they will be json encoded when added to the configuration so arrays can be utilized as needed
+// For a list of options see: https://developers.aviary.com/docs/web/setup-guide#constructor-config
+$aviary_options = array(
+    'apiKey' => 'dvh8qudbp6yx2bnp',
+    'apiVersion' => 3,
+    'language' => 'en'
+);
 
 
 //The filter and sorter are managed through both javascript and php scripts because if you have a lot of

--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -371,11 +371,21 @@ $get_params = http_build_query(array(
 	    };
 	    if (image_editor) {
 	    var featherEditor = new Aviary.Feather({
-		apiKey: "<?php echo $aviary_key; ?>",
-		apiVersion: <?php echo $aviary_version; ?>,
-		language: "<?php echo $aviary_language; ?>",
-	       theme: 'light',
-	       tools: 'all',
+	       <?php
+	        if (empty($aviary_options) || !is_array($aviary_options)) { $aviary_options = array(); }
+	        // First load any old format options into the array as needed
+	        $aviary_config_defaults = array(
+	            'theme' => 'light',
+	            'tools' => 'all'
+	        );
+	        if (!empty($aviary_key)) { $aviary_config_defaults['apiKey'] = $aviary_key; }
+	        if (!empty($aviary_version)) { $aviary_config_defaults['apiVersion'] = $aviary_version; }
+	        if (!empty($aviary_language)) { $aviary_config_defaults['language'] = $aviary_language; }
+	        $aviary_config = array_merge($aviary_config_defaults, $aviary_options);
+	        foreach ($aviary_config as $aopt_key => $aopt_val) {
+	       ?>
+		   <?php echo $aopt_key; ?>: <?php echo json_encode($aopt_val); ?>,
+		  <?php } ?>
 	       onSave: function(imageID, newURL) {
 		    show_animation();
 		    var img = document.getElementById(imageID);

--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -160,7 +160,6 @@ function fix_get_params($str)
 function fix_filename($str, $transliteration, $convert_spaces = false, $replace_with = "_")
 {
     if ($convert_spaces) {
-        $str = strtolower($str);
         $str = str_replace(' ', $replace_with, $str);
     }
 


### PR DESCRIPTION
Added the ability to supply extra Aviary configuration options in an
aviary_options array and moved configuration of existing Aviary options
to the new format (original format will still work for old config
files).

Also removed the lower casing of file names in fix_filename when
convert spaces is enabled- this was breaking saving of files with
uppercase letters and it’s unclear why it’s even part of the convert
spaces functionality.
