### PR TITLE
avoid include config.php twice, prevent redefinition notice msg

### DIFF
--- a/filemanager/upload.php
+++ b/filemanager/upload.php
@@ -1,8 +1,9 @@
 <?php
-$config = include 'config/config.php';
-//TODO switch to array
-extract($config, EXTR_OVERWRITE);
-
+if (!isset($config)){
+  $config = include 'config/config.php';
+  //TODO switch to array
+  extract($config, EXTR_OVERWRITE);
+}
 include 'include/utils.php';
 
 if ($_SESSION['RF']["verify"] != "RESPONSIVEfilemanager")


### PR DESCRIPTION
'upload.php' is currently only included from 'dialog.php', which has already included 'config.php'.
In some server, it will show notice message before the actual filename:

Notice:  A session had already been started - ignoring session_start() in ...../filemanager/config/config.php on line 2
Notice:  Constant USE_ACCESS_KEYS already defined in ...../filemanager/config/config.php on line 24
<Filename>