### PR TITLE
</div> missing, cause problem in some old brower

### DIFF
--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -434,6 +434,7 @@ $get_params = http_build_query($get_params);
 					<input type="hidden" name="lang" value="<?php echo $lang; ?>"/>
 					<input type="hidden" name="filter" value="<?php echo $filter; ?>"/>
 					<input type="submit" name="submit" value="<?php echo trans('OK')?>" />
+				    </div>
 				</form>
 			</div>
 		    <div class="upload-help"><?php echo trans('Upload_base_help'); ?></div>


### PR DESCRIPTION
missing < /div> cause IE8 confused, and the hidden input "path" and "path_thumb" disappear in DOM, which makes the upload malfunction (always upload files to the root directory)