### PR TITLE
update how to fire 'onchange' event, fix IE9 problem

### DIFF
--- a/resources/assets/js/plugin.js
+++ b/resources/assets/js/plugin.js
@@ -94,13 +94,13 @@ tinymce.PluginManager.add('filemanager', function(editor) {
 			setUrl: function (url) {
 				var fieldElm = win.document.getElementById(id);
 				fieldElm.value = editor.convertURL(url);
-				if ("fireEvent" in fieldElm) {
-					fieldElm.fireEvent("onchange")
-				} else {
-					var evt = document.createEvent("HTMLEvents");
-					evt.initEvent("change", false, true);
-					fieldElm.dispatchEvent(evt);
-				}
+			        if ("createEvent" in document) {
+			          var evt = document.createEvent("HTMLEvents");
+			          evt.initEvent("change", false, true);
+			          fieldElm.dispatchEvent(evt)
+			        } else {
+			          fieldElm.fireEvent("onchange")
+			        }
 			}
 		});
 	};

--- a/resources/assets/js/plugin.js
+++ b/resources/assets/js/plugin.js
@@ -94,13 +94,13 @@ tinymce.PluginManager.add('filemanager', function(editor) {
 			setUrl: function (url) {
 				var fieldElm = win.document.getElementById(id);
 				fieldElm.value = editor.convertURL(url);
-			        if ("createEvent" in document) {
-			          var evt = document.createEvent("HTMLEvents");
-			          evt.initEvent("change", false, true);
-			          fieldElm.dispatchEvent(evt)
-			        } else {
-			          fieldElm.fireEvent("onchange")
-			        }
+				if ("createEvent" in document) {
+					var evt = document.createEvent("HTMLEvents");
+					evt.initEvent("change", false, true);
+					fieldElm.dispatchEvent(evt)
+				} else {
+					fieldElm.fireEvent("onchange")
+				}
 			}
 		});
 	};


### PR DESCRIPTION
in IE9, insert a image/link won't fire 'onchange' event, and no image size & link description automatically fill.
because the fireEvent() exist in IE9 but not work.
I copied this code from MoxieManager (on TinyMCE offical website), works fine in Chrome, IE8 & IE9.