### PR TITLE
Set language at runtime

### DIFF
--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -32,6 +32,7 @@ if ( ! function_exists('trans'))
 	if ( ! isset($_SESSION['RF']['language'])
 		|| file_exists($_SESSION['RF']['language_file']) === false
 		|| ! is_readable($_SESSION['RF']['language_file'])
+		|| isset($_GET['lang'])
 	)
 	{
 		$lang = $default_language;


### PR DESCRIPTION
If $_SESSION['RF']['language'] is exist, but user still want to change at runtime, use `lang=vi_VN`, we check isset($_GET['lang']) too.