### PR TITLE
Fix memory_error bool indicator

### DIFF
--- a/filemanager/upload.php
+++ b/filemanager/upload.php
@@ -110,14 +110,14 @@ if ( ! empty($_FILES))
 			$memory_error = FALSE;
 			if ( ! create_img($targetFile, $targetFileThumb, 122, 91))
 			{
-				$memory_error = FALSE;
+				$memory_error = TRUE;
 			}
 			else
 			{
 				// TODO something with this long function baaaah...
 				if( ! new_thumbnails_creation($targetPath,$targetFile,$_FILES['file']['name'],$current_path,$relative_image_creation,$relative_path_from_current_pos,$relative_image_creation_name_to_prepend,$relative_image_creation_name_to_append,$relative_image_creation_width,$relative_image_creation_height,$relative_image_creation_option,$fixed_image_creation,$fixed_path_from_filemanager,$fixed_image_creation_name_to_prepend,$fixed_image_creation_to_append,$fixed_image_creation_width,$fixed_image_creation_height,$fixed_image_creation_option))
 				{
-					$memory_error = FALSE;
+					$memory_error = TRUE;
 				}
 				else
 				{


### PR DESCRIPTION
Small but strong fixes.
In two cases $memory_error need to be TRUE when create_img() and new_thumbnails_creation() return false.
Both return false when image_check_memory_usage() indicate that php memory_limit less than need to resize image.