### PR TITLE
Svg Upload Errors Fixed

### DIFF
--- a/filemanager/upload.php
+++ b/filemanager/upload.php
@@ -95,9 +95,9 @@ if ( ! empty($_FILES) || isset($_POST['url']))
 	}
 	$extension = get_extension_from_mime($mime_type);
 
-	if($extension=='so'){
-		$extension = $info['extension'];
-	}
+  if ($extension === '' || $extension == 'so') {
+        $extension = $info['extension'];
+  }
 
 	if (in_array(fix_strtolower($extension), $ext))
 	{
@@ -164,7 +164,7 @@ if ( ! empty($_FILES) || isset($_POST['url']))
 			}
 
 			$memory_error = FALSE;
-			if ( ! create_img($targetFile, $targetFileThumb, 122, 91))
+			if ( $extension != 'svg' && ! create_img($targetFile, $targetFileThumb, 122, 91))
 			{
 				$memory_error = TRUE;
 			}


### PR DESCRIPTION
When you upload a SVG file it is giving 'File extension is not allowed.' error. But SVG is allowed. The problem was when you upload a ext_img it is trying to crop it for thumbnail. But it can't be crop to svg .. So I added a extension control for svg before create thumbnail function. 

Thanks for this good plugin..