### PR TITLE
setlocale for correct transliteration

### DIFF
--- a/filemanager/config/config.php
+++ b/filemanager/config/config.php
@@ -8,6 +8,7 @@ mb_language('uni');
 mb_regex_encoding('UTF-8');
 ob_start('mb_output_handler');
 date_default_timezone_set('Europe/Rome');
+setlocale(LC_CTYPE, 'cs_CZ'); //correct transliteration
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Without setting this locale, transliteration of filenames inside iconv function failed (just ignored those chars). Sending you this pull req. Is it correct or can we discuss?