### PR TITLE
prevent 'Call to undefined function trans()' on line 65

### DIFF
--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -27,6 +27,20 @@ if ( ! function_exists('response'))
 
 if ( ! function_exists('trans'))
 {
+	/**
+	* Translate language variable
+	*
+	* @param $var string name
+	*
+	* @return string translated variable
+	*/
+	function trans($var)
+	{
+		global $lang_vars;
+
+		return (array_key_exists($var, $lang_vars)) ? $lang_vars[ $var ] : $var;
+	}
+
 	// language
 	if ( ! isset($_SESSION['RF']['language'])
 		|| file_exists('lang/' . basename($_SESSION['RF']['language']) . '.php') === false
@@ -76,19 +90,6 @@ if ( ! function_exists('trans'))
 	if ( ! is_array($lang_vars))
 	{
 		$lang_vars = array();
-	}
-	/**
-	* Translate language variable
-	*
-	* @param $var string name
-	*
-	* @return string translated variable
-	*/
-	function trans($var)
-	{
-		global $lang_vars;
-
-		return (array_key_exists($var, $lang_vars)) ? $lang_vars[ $var ] : $var;
 	}
 }
 


### PR DESCRIPTION
I'm getting that error on both php 5.x and 7.0 when trying to run the filemanager with a language which is not available (e.g. 'en' instead of 'en_EN').
Moving trans() right to the beginning will fix it.