### PR TITLE
Fix for thumbnail creation on files that say they are one file type but are actually another.

### DIFF
--- a/filemanager/include/php_image_magician.php
+++ b/filemanager/include/php_image_magician.php
@@ -2813,17 +2813,16 @@ class imageLib {
 			}
 		}
 
-		// *** Get extension / image type
-		$extension = mime_content_type($savePath);
+		// *** Get extension
+		$extension = strrchr($savePath, '.');
 		$extension = fix_strtolower($extension);
-		$extension = str_replace('image/', '', $extension);
 
 		$error = '';
 
 		switch ($extension)
 		{
-			case 'jpg':
-			case 'jpeg':
+			case '.jpg':
+			case '.jpeg':
 				$this->checkInterlaceImage($this->isInterlace);
 				if (imagetypes() & IMG_JPG)
 				{
@@ -2835,7 +2834,7 @@ class imageLib {
 				}
 				break;
 
-			case 'gif':
+			case '.gif':
 				$this->checkInterlaceImage($this->isInterlace);
 				if (imagetypes() & IMG_GIF)
 				{
@@ -2847,7 +2846,7 @@ class imageLib {
 				}
 				break;
 
-			case 'png':
+			case '.png':
 				// *** Scale quality from 0-100 to 0-9
 				$scaleQuality = round(($imageQuality / 100) * 9);
 
@@ -2865,7 +2864,7 @@ class imageLib {
 				}
 				break;
 
-			case 'bmp':
+			case '.bmp':
 				file_put_contents($savePath, $this->GD2BMPstring($this->imageResized));
 				break;
 

--- a/filemanager/include/php_image_magician.php
+++ b/filemanager/include/php_image_magician.php
@@ -2719,25 +2719,27 @@ class imageLib {
 			}
 		};
 
-		// *** Get extension
-		$extension = strrchr($file, '.');
+		// *** Get extension / image type
+		$extension = mime_content_type($file);
 		$extension = fix_strtolower($extension);
+		$extension = str_replace('image/', '', $extension);
 		switch ($extension)
 		{
-			case '.jpg':
-			case '.jpeg':
+			case 'jpg':
+			case 'jpeg':
 				$img = @imagecreatefromjpeg($file);
 				break;
-			case '.gif':
+			case 'gif':
 				$img = @imagecreatefromgif($file);
 				break;
-			case '.png':
+			case 'png':
 				$img = @imagecreatefrompng($file);
 				break;
-			case '.bmp':
+			case 'bmp':
 				$img = @$this->imagecreatefrombmp($file);
 				break;
-			case '.psd':
+			case 'psd':
+			case 'vnd.adobe.photoshop':
 				$img = @$this->imagecreatefrompsd($file);
 				break;
 
@@ -2811,16 +2813,17 @@ class imageLib {
 			}
 		}
 
-		// *** Get extension
-		$extension = strrchr($savePath, '.');
+		// *** Get extension / image type
+		$extension = mime_content_type($savePath);
 		$extension = fix_strtolower($extension);
+		$extension = str_replace('image/', '', $extension);
 
 		$error = '';
 
 		switch ($extension)
 		{
-			case '.jpg':
-			case '.jpeg':
+			case 'jpg':
+			case 'jpeg':
 				$this->checkInterlaceImage($this->isInterlace);
 				if (imagetypes() & IMG_JPG)
 				{
@@ -2832,7 +2835,7 @@ class imageLib {
 				}
 				break;
 
-			case '.gif':
+			case 'gif':
 				$this->checkInterlaceImage($this->isInterlace);
 				if (imagetypes() & IMG_GIF)
 				{
@@ -2844,7 +2847,7 @@ class imageLib {
 				}
 				break;
 
-			case '.png':
+			case 'png':
 				// *** Scale quality from 0-100 to 0-9
 				$scaleQuality = round(($imageQuality / 100) * 9);
 
@@ -2862,7 +2865,7 @@ class imageLib {
 				}
 				break;
 
-			case '.bmp':
+			case 'bmp':
 				file_put_contents($savePath, $this->GD2BMPstring($this->imageResized));
 				break;
 


### PR DESCRIPTION
E.g. if someone renames a png file to be .jpg then it previously caused a fatal error. (Actual error message hidden due to @ symbol / error suppressor usage in this file).

Example error message this fixes (once @ symbol removed from call):
```
Fatal error: imagecreatefromjpeg(): gd-jpeg: JPEG library reports unrecoverable error: Not a JPEG file: starts with 0x89 0x50 in .../filemanager/include/php_image_magician.php on line 2732
```