### PR TITLE
Path traversal filter bypass vulnerability fix

### DIFF
--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -41,14 +41,17 @@ if (isset($_GET['lang']))
 }
 include 'include/utils.php';
 
-if (isset($_GET['fldr'])
-	&& !empty($_GET['fldr'])
-	&& strpos($_GET['fldr'],'../') === FALSE
-	&& strpos($_GET['fldr'],'./') === FALSE
-	&& strpos($_GET['fldr'],'..\\') === FALSE
-	&& strpos($_GET['fldr'],'.\\') === FALSE)
+$subdir_path = '';
+if (isset($_GET['fldr']) && !empty($_GET['fldr'])) {
+	$subdir_path = rawurldecode(trim(strip_tags($_GET['fldr']),"/") ."/");
+}
+
+if (strpos($subdir_path,'../') === FALSE
+	&& strpos($subdir_path,'./') === FALSE
+	&& strpos($subdir_path,'..\\') === FALSE
+	&& strpos($subdir_path,'.\\') === FALSE)
 {
-	$subdir = rawurldecode(trim(strip_tags($_GET['fldr']),"/") ."/");
+	$subdir = $subdir_path;
 	$_SESSION['RF']["filter"]='';
 }
 else { $subdir = ''; }
@@ -393,7 +396,7 @@ $get_params = http_build_query($get_params);
 
 	<input type="hidden" id="ftp" value="<?php echo !!$ftp; ?>" />
 	<input type="hidden" id="popup" value="<?php echo $popup;?>" />
-	<input type="hidden" id="callback" value="<?php echo $callback; ?>" />	
+	<input type="hidden" id="callback" value="<?php echo $callback; ?>" />
 	<input type="hidden" id="crossdomain" value="<?php echo $crossdomain;?>" />
 	<input type="hidden" id="editor" value="<?php echo $editor;?>" />
 	<input type="hidden" id="view" value="<?php echo $view;?>" />


### PR DESCRIPTION
Because both `rawurldecode()` and `strip_tags()` mutate strings in a predictable way it is possible to bypass the path traversal checks that are being done using `strpos()`. Payloads such as `..%00/` and `..<>/` in `$_GET['fldr']` will pass the check but will later be mutated into `../` which allows directory traversal.

![poc](https://user-images.githubusercontent.com/25270497/34488239-f87541b8-efd7-11e7-805a-4b15df814fcf.png)

This commit moves the mutation of the path above the checks, this should prevent exploitation in this scenario.

But in all honesty, when I read through this project it feels like I am looking at a heap of patches on top of poor code. I've exploited this filemanager before, a few versions back. I even managed to gain remote code execution on a server, but I've never reported this to the project because the exploit had gotten fixed (probably on accident) in the next version.

I am not trying to start a fight, but people assume code is safe far too often. I consider it to be a developers duty to take this false sense of security into consideration when writing code and making sure it is in fact secure. In this new era of data protection laws people will suffer because of this.

I think this project needs to be rewritten from scratch, it seems impossible to me to guarantee security considering the state of this code. I am willing to contribute to a revived version of this project, otherwise you can consider this tiny fix to a quite obvious problem my first and final contribution to this project.