### PR TITLE
prevent sending JS undefined value

### DIFF
--- a/resources/assets/js/include.js
+++ b/resources/assets/js/include.js
@@ -638,7 +638,7 @@ var encodeURL,show_animation,hide_animation,apply,apply_none,apply_img,apply_any
 			});
 			jQuery('#fileupload').bind('fileuploadsubmit', function (e, data) {
 				// The example input, doesn't have to be part of the upload form:
-				data.formData = {fldr: jQuery('#sub_folder').val() + jQuery('#fldr_value').val()+data.files[0].relativePath};
+				data.formData = {fldr: jQuery('#sub_folder').val() + jQuery('#fldr_value').val()+(data.files[0].relativePath || data.files[0].webkitRelativePath || '')};
 			});
 			// Load existing files:
 			jQuery('#fileupload').addClass('fileupload-processing');


### PR DESCRIPTION
When uploading just one file, ajax request sends `path/undefined` value. This change will fix this issue.