### PR TITLE
Update include.js

### DIFF
--- a/resources/assets/js/include.js
+++ b/resources/assets/js/include.js
@@ -992,6 +992,14 @@ var encodeURL,show_animation,hide_animation,apply,apply_none,apply_img,apply_any
 			});
 			return files;
 		};
+		var getDeleteFiles = function(){
+			var files = [];
+			jQuery('.selection:checkbox:checked:visible').each(function () {
+				var file = jQuery(this).closest('figure').attr('data-path');
+				files.push(file);
+			});
+			return files;
+		};
 
 		jQuery('.multiple-action-btn').on('click',function(){
 			var files = getFiles();
@@ -1016,7 +1024,7 @@ var encodeURL,show_animation,hide_animation,apply,apply_none,apply_img,apply_any
 			{
 				if (result == true)
 				{
-					var files = getFiles(true);
+					var files = getDeleteFiles();
 					execute_multiple_action('delete_files', files, '', '', '');
 					var fil = jQuery('#files_number');
 					fil.text(parseInt(fil.text())-files.length);


### PR DESCRIPTION
Fix delete multiple select in subdir.
When files are saved in user subfolder instead of all to the root, the multiple select delete action returns only the filename and not the full filepath.
If i want to change to getFiles() function this has impact on the apply_img() function. So for now i just added a new function for the delete only.