### PR TITLE
Fix foreach issue on URL upload

### DIFF
--- a/filemanager/upload.php
+++ b/filemanager/upload.php
@@ -166,13 +166,19 @@ try {
     $upload_handler = new UploadHandler($uploadConfig, true, $messages);
 } catch (Exception $e) {
     $return = array();
-    foreach ($_FILES['files']['name'] as $i => $name) {
-        $return[] = array(
-            'name' => $name,
-            'error' => $e->getMessage(),
-            'size' => $_FILES['files']['size'][$i],
-            'type' => $_FILES['files']['type'][$i]
-        );
+    if ($_FILES['files']) {
+        foreach ($_FILES['files']['name'] as $i => $name) {
+            $return[] = array(
+                'name' => $name,
+                'error' => $e->getMessage(),
+                'size' => $_FILES['files']['size'][$i],
+                'type' => $_FILES['files']['type'][$i]
+            );
+        }
+
+        echo json_encode(array("files" => $return));
+        return;
     }
-    echo json_encode(array("files" => $return));
+
+    echo json_encode(array("error" =>$e->getMessage()));
 }


### PR DESCRIPTION
Fix foreach warning on URL upload

Example: upload img from http source, then preg_match pattern in code is true, and we have Exception('Is not a valid URL.');
Then in Catch block we dont have a file to loop trought foreach and get warning