### PR TITLE
Improve memory usage estimates

### DIFF
--- a/filemanager/include/get_png_imageinfo.php
+++ b/filemanager/include/get_png_imageinfo.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ *
+ * This code was originally taken from:
+ * https://github.com/ktomk/Miscellaneous/blob/master/get_png_imageinfo/get_png_imageinfo.php
+ * It has been modified to fix bugs and improve code formatting
+ *
+ * Get image-information from PNG file
+ *
+ * php's getimagesize does not support additional image information
+ * from PNG files like channels or bits.
+ *
+ * get_png_imageinfo() can be used to obtain this information
+ * from PNG files.
+ *
+ * @author Tom Klingenberg <lastflood.net>
+ * @license Apache 2.0
+ * @link https://github.com/ktomk/Miscellaneous/blob/master/get_png_imageinfo/get_png_imageinfo.php
+ * @link http://www.libpng.org/pub/png/spec/iso/index-object.html#11IHDR
+ *
+ * @param string $file filename
+ * @return array|bool image information, FALSE on error
+ */
+function get_png_imageinfo($file) {
+    if (! is_file($file)) {
+        return false;
+    }
+
+    $info = unpack(
+        'a8sig/Nchunksize/A4chunktype/Nwidth/Nheight/Cbit-depth/Ccolor/Ccompression/Cfilter/Cinterface',
+        file_get_contents($file, 0, null, 0, 29)
+    );
+    
+    if (empty($info)) {
+        return false;
+    }
+    if ("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A" != array_shift($info)) {
+        return false; // no PNG signature
+    }
+    if (13 != array_shift($info)) {
+        return false; // wrong length for IHDR chunk
+    }
+    if ('IHDR'!==array_shift($info)) {
+        return false; // a non-IHDR chunk singals invalid data
+    }
+
+    $color = $info['color'];
+    $type = array(
+        0 => 'Greyscale',
+        2 => 'Truecolour',
+        3 => 'Indexed-colour',
+        4 => 'Greyscale with alpha',
+        6 => 'Truecolour with alpha'
+    );
+
+    if (empty($type[$color])) {
+        return false; // invalid color value
+    }
+
+    $info['color-type'] = $type[$color];
+    $samples = ((($color % 4) % 3) ? 3 : 1) + ($color > 3 ? 1 : 0);
+    $info['channels'] = $samples;
+    $info['bits'] = $info['bit-depth'];
+
+    return $info;
+}

--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -847,12 +847,23 @@ function image_check_memory_usage($img, $max_breedte, $max_hoogte)
             $image_properties = getimagesize($img);
             $image_width = $image_properties[0];
             $image_height = $image_properties[1];
+
             $image_bits = 0;
             $image_channels = 0;
             if (isset($image_properties['bits'])) {
                 $image_bits = $image_properties['bits'];
                 $image_channels = isset($image_properties['channels']) ? $image_properties['channels'] : 1;
             }
+
+            if ($image_properties[2] == IMAGETYPE_GIF) {
+                // GIF supports up to 8 bits per pixel
+                if (empty($image_bits)) {
+                    $image_bits = 8;
+                }
+                // GIF uses indexed color which obviates channels
+                $image_channels = 1;
+            }
+
             $image_memory_usage = $K64 + ($image_width * $image_height * ($image_bits * $image_channels / 8) * 2);
             $thumb_memory_usage = $K64 + ($max_breedte * $max_hoogte * ($image_bits * $image_channels / 8) * 2);
             $memory_needed = abs(intval($memory_usage + $image_memory_usage + $thumb_memory_usage));

--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -844,7 +844,9 @@ function image_check_memory_usage($img, $max_breedte, $max_hoogte)
                 $memory_limit = abs(intval(str_replace(array('G'), '', $mem) * 1024 * 1024 * 1024));
             }
 
-            $image_properties = getimagesize($img);
+            if (($image_properties = getimagesize($img)) === false) {
+                return false;
+            }
             $image_width = $image_properties[0];
             $image_height = $image_properties[1];
 

--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -850,7 +850,7 @@ function image_check_memory_usage($img, $max_breedte, $max_hoogte)
 
             if ($image_properties[2] == IMAGETYPE_PNG) {
                 // PHP's getimagesize() doesn't return the number of channels for PNG files
-                require_once 'get_png_imageinfo.php';
+                require_once __DIR__ . '/get_png_imageinfo.php';
                 if ($png_properties = get_png_imageinfo($img)) {
                     $image_properties['bits'] = $png_properties['bits'];
                     $image_properties['channels'] = $png_properties['channels'];

--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -848,6 +848,15 @@ function image_check_memory_usage($img, $max_breedte, $max_hoogte)
             $image_width = $image_properties[0];
             $image_height = $image_properties[1];
 
+            if ($image_properties[2] == IMAGETYPE_PNG) {
+                // PHP's getimagesize() doesn't return the number of channels for PNG files
+                require_once 'get_png_imageinfo.php';
+                if ($png_properties = get_png_imageinfo($img)) {
+                    $image_properties['bits'] = $png_properties['bits'];
+                    $image_properties['channels'] = $png_properties['channels'];
+                }
+            }
+
             $image_bits = 0;
             $image_channels = 0;
             if (isset($image_properties['bits'])) {

--- a/filemanager/include/utils.php
+++ b/filemanager/include/utils.php
@@ -847,13 +847,14 @@ function image_check_memory_usage($img, $max_breedte, $max_hoogte)
             $image_properties = getimagesize($img);
             $image_width = $image_properties[0];
             $image_height = $image_properties[1];
+            $image_bits = 0;
+            $image_channels = 0;
             if (isset($image_properties['bits'])) {
                 $image_bits = $image_properties['bits'];
-            } else {
-                $image_bits = 0;
+                $image_channels = isset($image_properties['channels']) ? $image_properties['channels'] : 1;
             }
-            $image_memory_usage = $K64 + ($image_width * $image_height * ($image_bits >> 3) * 2);
-            $thumb_memory_usage = $K64 + ($max_breedte * $max_hoogte * ($image_bits >> 3) * 2);
+            $image_memory_usage = $K64 + ($image_width * $image_height * ($image_bits * $image_channels / 8) * 2);
+            $thumb_memory_usage = $K64 + ($max_breedte * $max_hoogte * ($image_bits * $image_channels / 8) * 2);
             $memory_needed = abs(intval($memory_usage + $image_memory_usage + $thumb_memory_usage));
 
             if ($memory_needed > $memory_limit) {


### PR DESCRIPTION
This addresses issue #538. It improves the accuracy of memory usage estimates which can prevent the script from exceeding PHP's memory limit when processing certain (large) images.