### PR TITLE
Fix: Respect url upload configuration also in upload logic

### DIFF
--- a/filemanager/upload.php
+++ b/filemanager/upload.php
@@ -64,37 +64,38 @@ try {
         $messages = trans("Upload_error_messages");
     }
 
-    // make sure the length is limited to avoid DOS attacks
-    if (isset($_POST['url']) && strlen($_POST['url']) < 2000) {
-        $url = $_POST['url'];
-        $urlPattern = '/^(https?:\/\/)?([\da-z\.-]+\.[a-z\.]{2,6}|[\d\.]+)([\/?=&#]{1}[\da-z\.-]+)*[\/\?]?$/i';
+    if ($config['url_upload']) {
+        // make sure the length is limited to avoid DOS attacks
+        if (isset($_POST['url']) && strlen($_POST['url']) < 2000) {
+            $url = $_POST['url'];
+            $urlPattern = '/^(https?:\/\/)?([\da-z\.-]+\.[a-z\.]{2,6}|[\d\.]+)([\/?=&#]{1}[\da-z\.-]+)*[\/\?]?$/i';
 
-        if (preg_match($urlPattern, $url)) {
-            $temp = tempnam('/tmp','RF');
+            if (preg_match($urlPattern, $url)) {
+                $temp = tempnam('/tmp','RF');
 
-            $ch = curl_init($url);
-            $fp = fopen($temp, 'wb');
-            curl_setopt($ch, CURLOPT_FILE, $fp);
-            curl_setopt($ch, CURLOPT_HEADER, 0);
-            curl_exec($ch);
-            if (curl_errno($ch)) {
+                $ch = curl_init($url);
+                $fp = fopen($temp, 'wb');
+                curl_setopt($ch, CURLOPT_FILE, $fp);
+                curl_setopt($ch, CURLOPT_HEADER, 0);
+                curl_exec($ch);
+                if (curl_errno($ch)) {
+                    curl_close($ch);
+                    throw new Exception('Invalid URL');
+                }
                 curl_close($ch);
-                throw new Exception('Invalid URL');
-            }
-            curl_close($ch);
-            fclose($fp);
+                fclose($fp);
 
-            $_FILES['files'] = array(
-                'name' => array(basename($_POST['url'])),
-                'tmp_name' => array($temp),
-                'size' => array(filesize($temp)),
-                'type' => null
-            );
-        } else {
-            throw new Exception('Is not a valid URL.');
+                $_FILES['files'] = array(
+                    'name' => array(basename($_POST['url'])),
+                    'tmp_name' => array($temp),
+                    'size' => array(filesize($temp)),
+                    'type' => null
+                );
+            } else {
+                throw new Exception('Is not a valid URL.');
+            }
         }
     }
-
 
     if ($config['mime_extension_rename']) {
         $info = pathinfo($_FILES['files']['name'][0]);


### PR DESCRIPTION
Config has switch for url_upload, but it only hides the upload by url
on frontend if disabled. Logic that accepts the url didn't respect
the settings, thus allowing to use the function even if it is disabled.
