### PR TITLE
Fix #646, adds an option to keep existing files intact

### DIFF
--- a/filemanager/config/config.php
+++ b/filemanager/config/config.php
@@ -260,6 +260,9 @@ $config = array(
     'replace_with'                     => "_",
     //convert to lowercase the files and folders name
     'lower_case'                    => false,
+    //Should we rename (translitareation and convert_space) files that are already on the filesystem (true)
+    //or only the news files (false => keeps the existing files and folders intact)
+    'fix_existing_files'            => true,
 
     //Add ?484899493349 (time value) to returned images to prevent cache
     'add_time_to_img'                       => false,

--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -1035,7 +1035,7 @@ if ($config['load_more']) {
                 continue;
             }
             $new_name=fix_filename($file,$config);
-            if($ftp && $file!='..' && $file!=$new_name){
+            if($ftp && $file!='..' && $file!=$new_name && !empty($config['fix_existing_files']){
                 //rename
                 rename_folder($config['current_path'].$subdir.$file,$new_name,$ftp,$config);
                 $file=$new_name;
@@ -1138,7 +1138,7 @@ if ($config['load_more']) {
                     $file_path=$config['current_path'].$rfm_subfolder.$subdir.$file;
                     //check if file have illegal caracter
 
-                    if($file!=fix_filename($file,$config)){
+                    if(!empty($config['fix_existing_files'] && $file!=fix_filename($file,$config)){
                         $file1=fix_filename($file,$config);
                         $file_path1=($config['current_path'].$rfm_subfolder.$subdir.$file1);
                         if(file_exists($file_path1)){


### PR DESCRIPTION
This PR adds an option in the config to prevent ResponsiveFileManager to rename files that already exist on the filesystem.
This allows you to enable `transliteration `and `convert_spaces` on an existing folder without ResponsiveFileManager renaming your existing files.