### PR TITLE
PHP 8.0 fixes

### DIFF
--- a/filemanager/config/config.php
+++ b/filemanager/config/config.php
@@ -6,7 +6,6 @@ if (session_id() == '') {
 
 mb_internal_encoding('UTF-8');
 mb_http_output('UTF-8');
-mb_http_input('UTF-8');
 mb_language('uni');
 mb_regex_encoding('UTF-8');
 ob_start('mb_output_handler');

--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -1184,7 +1184,7 @@ if ($config['load_more']) {
                         $creation_thumb_path = $mini_src = $src_thumb = $thumbs_path. $file;
 
                         if (!file_exists($src_thumb)) {
-                            if (!create_img($file_path, $creation_thumb_path, 122, 91, 'crop', $config)) {
+                            if (create_img($file_path, $creation_thumb_path, 122, 91, 'crop', $config) !== true) {
                                 $src_thumb = $mini_src = "";
                             }
                         }

--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -719,12 +719,13 @@ function filenameSort($x, $y)
     global $descending;
 
     if ($x['is_dir'] !== $y['is_dir']) {
-        return $y['is_dir'];
+        $greater = $y['is_dir'];
     } else {
-        return ($descending)
+        $greater = ($descending)
             ? $x['file_lcase'] < $y['file_lcase']
             : $x['file_lcase'] >= $y['file_lcase'];
     }
+	return $greater ? 1 : -1;
 }
 
 function dateSort($x, $y)
@@ -732,12 +733,13 @@ function dateSort($x, $y)
     global $descending;
 
     if ($x['is_dir'] !== $y['is_dir']) {
-        return $y['is_dir'];
+        $greater = $y['is_dir'];
     } else {
-        return ($descending)
+        $greater = ($descending)
             ? $x['date'] < $y['date']
             : $x['date'] >= $y['date'];
     }
+	return $greater ? 1 : -1;
 }
 
 function sizeSort($x, $y)
@@ -745,12 +747,13 @@ function sizeSort($x, $y)
     global $descending;
 
     if ($x['is_dir'] !== $y['is_dir']) {
-        return $y['is_dir'];
+        $greater = $y['is_dir'];
     } else {
-        return ($descending)
+        $greater = ($descending)
             ? $x['size'] < $y['size']
             : $x['size'] >= $y['size'];
     }
+	return $greater ? 1 : -1;
 }
 
 function extensionSort($x, $y)
@@ -758,12 +761,13 @@ function extensionSort($x, $y)
     global $descending;
 
     if ($x['is_dir'] !== $y['is_dir']) {
-        return $y['is_dir'];
+        $greater = $y['is_dir'];
     } else {
-        return ($descending)
+        $greater = ($descending)
             ? $x['extension'] < $y['extension']
             : $x['extension'] >= $y['extension'];
     }
+	return $greater ? 1 : -1;
 }
 
 switch ($sort_by) {

--- a/filemanager/include/php_image_magician.php
+++ b/filemanager/include/php_image_magician.php
@@ -2792,7 +2792,7 @@ class imageLib {
 	{
 
 		// *** Perform a check or two.
-		if ( ! is_resource($this->imageResized))
+		if (! is_resource($this->imageResized) && ! $this->imageResized instanceof \GdImage)
 		{
 			if ($this->debug)
 			{
@@ -2914,7 +2914,7 @@ class imageLib {
 		#
 	{
 
-		if ( ! is_resource($this->imageResized))
+		if (! is_resource($this->imageResized) && ! $this->imageResized instanceof \GdImage)
 		{
 			if ($this->debug)
 			{
@@ -3488,7 +3488,7 @@ class imageLib {
 		# Notes:
 		#
 	{
-		if ( ! is_resource($img))
+		if (! is_resource($img) && ! $img instanceof \GdImage)
 		{
 			return false;
 		}
@@ -3737,7 +3737,7 @@ class imageLib {
 
 	public function __destruct()
 	{
-		if (is_resource($this->imageResized))
+		if (is_resource($this->imageResized) || $this->imageResized instanceof \GdImage)
 		{
 			imagedestroy($this->imageResized);
 		}


### PR DESCRIPTION
When switching my website to PHP 8.0 I encountered the following errors:

- 500 error due to `mb_http_input('UTF-8')` which is an invalid value.
- The GD extension functions return a GdImage instance instead of a resource breaking the thumbnail creation (and probably some other image related functions).
- When the `create_img` function threw an exception, the filemanager wouldn't show a (default) thumbnail (on any PHP version).