### PR TITLE
Prevent recursive fix_filename calls on already fixed file_path's

### DIFF
--- a/filemanager/dialog.php
+++ b/filemanager/dialog.php
@@ -1491,7 +1491,7 @@ if ($config['upload_files']) { ?>
                         if (strlen($file_array['extension']) === 0) {
                             $filename = $file1;
                         }
-                        rename_file($file_path, fix_filename($filename, $config), $ftp, $config);
+                        rename_file($file_path1, fix_filename($filename, $config), $ftp, $config);
                         $file = $file1;
                         $file_array['extension'] = fix_filename($file_array['extension'], $config);
                         $file_path = $file_path1;


### PR DESCRIPTION
Mainly noticed problems with filenames that contained '&', but I imagine this is an oversight anyway looking at the overall flow of the logic. Prevents filenames with '&' from recursively being sanitized by utils.php->sanitize, where 'amp;' would be recursively placed into the string.