### PR TITLE
Selecting file and placing into the editor fails - fixed

### DIFF
--- a/resources/assets/js/plugin.js
+++ b/resources/assets/js/plugin.js
@@ -76,7 +76,7 @@ tinymce.PluginManager.add('filemanager', function(editor) {
 		}
 
 		window.addEventListener('message', function receiveMessage(event) {
-			window.removeEventListener('message', receiveMessage, false);
+			//window.removeEventListener('message', receiveMessage, false);
 			if (event.data.sender === 'responsivefilemanager') {
 				callback(event.data.url);
 			}


### PR DESCRIPTION
Chosen file's path is not being placed into appropriate field of Image native TinyMCE plugin dialog thus file cannot be selected and put into editor. That was fixed.